### PR TITLE
Fix Ruby 3.0.0 compatibility: Remove shorthand keyword arguments

### DIFF
--- a/lib/spot_feel/dmn/decision.rb
+++ b/lib/spot_feel/dmn/decision.rb
@@ -10,7 +10,14 @@ module SpotFeel
         decision_table = DecisionTable.from_json(json[:decision_table]) if json[:decision_table]
         literal_expression = LiteralExpression.from_json(json[:literal_expression]) if json[:literal_expression]
         variable = Variable.from_json(json[:variable]) if json[:variable]
-        Decision.new(id: json[:id], name: json[:name], decision_table:, variable:, literal_expression:, information_requirements:)
+        Decision.new(
+          id: json[:id],
+          name: json[:name],
+          decision_table: decision_table,
+          variable: variable,
+          literal_expression: literal_expression,
+          information_requirements: information_requirements
+        )
       end
 
       def initialize(id:, name:, decision_table:, variable:, literal_expression:, information_requirements:)


### PR DESCRIPTION
Fix Ruby 3.0.0 compatibility: Remove shorthand keyword arguments

- Updates Decision.from_json to use explicit key-value pairs instead of shorthand syntax
- Ensures compatibility with Ruby 3.0.0 which doesn't support parameter:, syntax